### PR TITLE
Moved the code to observe for the UIApplicationDidFinishLaunchingNoti…

### DIFF
--- a/Analytics/Integrations/Kahuna/SEGKahunaIntegration.h
+++ b/Analytics/Integrations/Kahuna/SEGKahunaIntegration.h
@@ -20,9 +20,10 @@
 
 
 @interface SEGKahunaPushMonitor : NSObject
-@property (nonatomic) NSDictionary *pushInfo;
-@property (nonatomic) UIApplicationState applicationState;
-@property (nonatomic) BOOL kahunaInitialized;
+@property (atomic) NSDictionary *pushInfo;
+@property (atomic) UIApplicationState applicationState;
+@property (atomic) BOOL kahunaInitialized;
+@property (atomic) NSError *failedToRegisterError;
 @property Class kahunaClass;
 
 + (instancetype)sharedInstance;


### PR DESCRIPTION
…fication into the + load method of the SEGKahunaIntegration class. This will allow us to swizzle the following methods even before Kahuna is instantiated.

- (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo completionHandler:(void (^)())completionHandler
- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler
- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo
- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error

Even though these methods are swizzled we check to see if Kahuna is instantiated before forwarding it to Kahuna SDK. Till then we store it in SEGKahunaPushMonitor class as atomic variables. Inside the swizzled method we use [SEGKahunaPushMonitor sharedInstance] instead of using "self". Self in this case refers to the object that has the swizzled method (i.e. AppDelegate). This was causing issues since pushReceived is not a method of the AppDelegate. Changing it to [SEGKahunaPushMonitor sharedInstance] resolved this issue.